### PR TITLE
Allow php 5.4 and added badge for codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - "7.0"
   - "5.6"
   - "5.5"
+  - "5.4"
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Taggable PSR-6 cache
-[![Build Status](https://travis-ci.org/php-cache/taggable-cache.svg)](https://travis-ci.org/php-cache/taggable-cache)
+[![Build Status](https://travis-ci.org/php-cache/taggable-cache.svg)](https://travis-ci.org/php-cache/taggable-cache) [![codecov.io](https://codecov.io/github/php-cache/taggable-cache/coverage.svg?branch=master)](https://codecov.io/github/php-cache/taggable-cache?branch=master)
 
 This repository has one trait and one interfaces that makes a PSR-6 cache implementation taggable. Using tags allow you 
 to tag related items, and then clear the cached data for that tag only.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require":
     {
-        "php":       "^5.5|^7",
+        "php":       "^5.4|^7",
         "psr/cache": "1.0.0"
     },
     "require-dev":  {


### PR DESCRIPTION
This PR https://github.com/matthiasmullie/scrapbook/pull/5 fails because we do not allow php 5.4
