### PR TITLE
We do not have to gerenerate a new key if we do not use tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,26 @@ class Pool implements CacheItemPoolInterface, TaggablePoolInterface
 
 ### Implement interface and use trait for CacheItemInterface
 
-The purpose of the trait is to be able to return a `taggedKey` and a normal `key`. Use the trait and rename your
-`getKey()` to `getTaggedKey()`. 
+The purpose of the trait is to be able to return a `taggedKey` and a normal `key`. The trait has one protected function 
+`getKeyFromTaggedKey()` and one public function `getTaggedkey()`. You should use the trait and make sure you set values
+to your two keys. 
 
 ```php
 class Pool implements CacheItemInterface, TaggableItemInterface
 {
   use TaggableItemTrait;
   
-  private $key;
+  private $normalKey;
   
-  // Rename from getKey to getTaggedKey
-  public function getTaggedKey() 
+  public function __construct($key)
   {
-    return $this->key;
+    $this->taggedKey = $key;
+    $this->normalKey = $this->getKeyFromTaggedKey($key);
+  }
+  
+  public function getKey() 
+  {
+    return $this->normalKey;
   }
   
   // ...

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You need to do a few changes on the implementation of `CacheItemPoolInterface`.
 * Implement `TaggableItemInterface` and use `TaggableItemTrait`
 * Use `TaggablePoolTrait::generateCacheKey($key, array $tags)` 
 * Use `TaggableItemInterface::getTaggedKey()` 
-* Implement `CachePool::getTagItem($key)`
+* Implement `CachePool::getItemWithoutGenerateCacheKey($key)`
 
 
 ### Implement interface and use trait for Pool
@@ -155,10 +155,10 @@ public function save(CacheItemInterface $item)
 }
 ```
 
-### Implement CachePool::getTagItem($key)
+### Implement CachePool::getItemWithoutGenerateCacheKey($key)
 
 The trait uses the cache as a key-value store. The key is the tag name and the value is a random id created by 
-`uniqid()`. The way to access the cache is by a protected function `getTagItem($key)`. This function will be very similar to your 
+`uniqid()`. The way to access the cache is by a protected function `getItemWithoutGenerateCacheKey($key)`. This function will be very similar to your 
 `getItem($key, array $tags = [])`. The only difference is that the latter will call `generateCacheKey()`. 
 
 Consider your new `getItem($key, array $tags = [])`:
@@ -176,9 +176,9 @@ public function getItem($key, array $tags = [])
 }
 ```
 
-You would need `getTagItem($key)` to look like this: 
+You would need `getItemWithoutGenerateCacheKey($key)` to look like this: 
 ```php
-protected function getTagItem($key)
+protected function getItemWithoutGenerateCacheKey($key)
 {
   $item = $this->storage->fetch($key);
   if (false === $item) {
@@ -195,10 +195,10 @@ public function getItem($key, array $tags = [])
 {
   $taggedKey = $this->generateCacheKey($key, $tags);
   
-  return $this->getTagItem($taggedKey);
+  return $this->getItemWithoutGenerateCacheKey($taggedKey);
 }
 
-protected function getTagItem($key)
+protected function getItemWithoutGenerateCacheKey($key)
 {
   $item = $this->storage->fetch($key);
   if (false === $item) {

--- a/src/TaggableItemInterface.php
+++ b/src/TaggableItemInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of php-cache\taggable-cache package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Taggable;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface TaggableItemInterface
+{
+    /**
+     * Get the key with the tag prefix.
+     *
+     * @return string
+     */
+    public function getTaggedKey();
+}

--- a/src/TaggableItemTrait.php
+++ b/src/TaggableItemTrait.php
@@ -17,22 +17,31 @@ namespace Cache\Taggable;
 trait TaggableItemTrait
 {
     /**
-     * @return string
+     * @type string
      */
-    abstract public function getTaggedKey();
+    protected $taggedKey;
 
     /**
-     * Return the key for this item.
+     * A key that is dependent on the tags.
      *
      * @return string
      */
-    public function getKey()
+    public function getTaggedKey()
     {
-        $key = $this->getTaggedKey();
-        if (false === $pos = strrpos($key, ':')) {
-            return $key;
+        return $this->taggedKey;
+    }
+
+    /**
+     * Return the cache key for this item. This is the generic cache key that the calling library sees.
+     *
+     * @return string
+     */
+    protected function getKeyFromTaggedKey($taggedKey)
+    {
+        if (false === $pos = strrpos($taggedKey, ':')) {
+            return $taggedKey;
         }
 
-        return substr($key, $pos + 1);
+        return substr($taggedKey, $pos + 1);
     }
 }

--- a/src/TaggableItemTrait.php
+++ b/src/TaggableItemTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of php-cache\taggable-cache package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Taggable;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+trait TaggableItemTrait
+{
+    /**
+     * @return string
+     */
+    abstract public function getTaggedKey();
+
+    /**
+     * Return the key for this item.
+     *
+     * @return string
+     */
+    public function getKey()
+    {
+        $key = $this->getTaggedKey();
+        if (false === $pos = strrpos($key, ':')) {
+            return $key;
+        }
+
+        return substr($key, $pos + 1);
+    }
+}

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -47,7 +47,7 @@ trait TaggablePoolTrait
      *
      * @return CacheItemInterface
      */
-    abstract protected function getTagItem($key);
+    abstract protected function getItemWithoutGenerateCacheKey($key);
 
     /**
      * Reset the tag and return the new tag identifier.
@@ -60,7 +60,7 @@ trait TaggablePoolTrait
      */
     protected function flushTag($name)
     {
-        $item = $this->getTagItem($this->getTagKey($name));
+        $item = $this->getItemWithoutGenerateCacheKey($this->getTagKey($name));
 
         return $this->generateNewTagId($item);
     }
@@ -100,7 +100,7 @@ trait TaggablePoolTrait
      */
     private function getTagId($name)
     {
-        $item = $this->getTagItem($this->getTagKey($name));
+        $item = $this->getItemWithoutGenerateCacheKey($this->getTagKey($name));
 
         if ($item->isHit()) {
             return $item->get();

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -50,6 +50,13 @@ trait TaggablePoolTrait
     abstract protected function getItemWithoutGenerateCacheKey($key);
 
     /**
+     * Make sure we do not use any invalid characters in the tag name. The actual tag name will be "tag:$name".
+     *
+     * @param string $name
+     */
+    abstract protected function validateTagName($name);
+
+    /**
      * Reset the tag and return the new tag identifier.
      *
      * This will not delete anything form cache, only generate a new reference. This is a memory leak.
@@ -60,6 +67,7 @@ trait TaggablePoolTrait
      */
     protected function flushTag($name)
     {
+        $this->validateTagName($name);
         $item = $this->getItemWithoutGenerateCacheKey($this->getTagKey($name));
 
         return $this->generateNewTagId($item);
@@ -100,6 +108,7 @@ trait TaggablePoolTrait
      */
     private function getTagId($name)
     {
+        $this->validateTagName($name);
         $item = $this->getItemWithoutGenerateCacheKey($this->getTagKey($name));
 
         if ($item->isHit()) {

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -75,6 +75,10 @@ trait TaggablePoolTrait
      */
     protected function generateCacheKey($key, array $tags)
     {
+        if (empty($tags)) {
+            return $key;
+        }
+
         // We sort the tags because the order should not matter
         sort($tags);
 
@@ -114,7 +118,7 @@ trait TaggablePoolTrait
      */
     private function getTagKey($name)
     {
-        return 'tag:'.$name.':key';
+        return 'tag:'.$name;
     }
 
     /**

--- a/tests/Helper/CacheItem.php
+++ b/tests/Helper/CacheItem.php
@@ -11,10 +11,14 @@
 
 namespace Cache\Taggable\Tests\Helper;
 
+use Cache\Taggable\TaggableItemInterface;
+use Cache\Taggable\TaggableItemTrait;
 use Psr\Cache\CacheItemInterface;
 
-class CacheItem implements CacheItemInterface
+class CacheItem implements CacheItemInterface, TaggableItemInterface
 {
+    use TaggableItemTrait;
+
     /**
      * @type string
      */
@@ -49,7 +53,7 @@ class CacheItem implements CacheItemInterface
     /**
      * @return string
      */
-    public function getKey()
+    public function getTaggedKey()
     {
         return $this->key;
     }

--- a/tests/Helper/CacheItem.php
+++ b/tests/Helper/CacheItem.php
@@ -39,7 +39,8 @@ class CacheItem implements CacheItemInterface, TaggableItemInterface
      */
     public function __construct($key)
     {
-        $this->key = $key;
+        $this->taggedKey = $key;
+        $this->key       = $this->getKeyFromTaggedKey($key);
     }
 
     /**
@@ -53,7 +54,7 @@ class CacheItem implements CacheItemInterface, TaggableItemInterface
     /**
      * @return string
      */
-    public function getTaggedKey()
+    public function getKey()
     {
         return $this->key;
     }

--- a/tests/Helper/CachePool.php
+++ b/tests/Helper/CachePool.php
@@ -48,7 +48,7 @@ class CachePool
 
     public function save(CacheItemInterface $item)
     {
-        $this->memoryCache[$item->getKey()] = $item;
+        $this->memoryCache[$item->getTaggedKey()] = $item;
 
         return true;
     }

--- a/tests/Helper/CachePool.php
+++ b/tests/Helper/CachePool.php
@@ -32,10 +32,10 @@ class CachePool
     {
         $taggedKey = $this->generateCacheKey($key, $tags);
 
-        return $this->getTagItem($taggedKey);
+        return $this->getItemWithoutGenerateCacheKey($taggedKey);
     }
 
-    protected function getTagItem($key)
+    protected function getItemWithoutGenerateCacheKey($key)
     {
         if (isset($this->memoryCache[$key])) {
             $item = $this->memoryCache[$key];

--- a/tests/Helper/CachePool.php
+++ b/tests/Helper/CachePool.php
@@ -28,6 +28,10 @@ class CachePool
      */
     private $memoryCache;
 
+    protected function validateTagName($name)
+    {
+    }
+
     public function getItem($key, array $tags = [])
     {
         $taggedKey = $this->generateCacheKey($key, $tags);

--- a/tests/TaggableItemTraitTest.php
+++ b/tests/TaggableItemTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of php-cache\taggable-cache package.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Taggable\Tests;
+
+use Cache\Taggable\Tests\Helper\CacheItem;
+
+class TaggableItemTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetKey()
+    {
+        $item = new CacheItem('key');
+        $this->assertEquals('key', $item->getKey());
+
+        $item = new CacheItem('foo:key');
+        $this->assertEquals('key', $item->getKey());
+
+        $item = new CacheItem('foo:bar:key');
+        $this->assertEquals('key', $item->getKey());
+    }
+
+    public function testGetTaggedKey()
+    {
+        $item = new CacheItem('key');
+        $this->assertEquals('key', $item->getTaggedKey());
+
+        $item = new CacheItem('foo:key');
+        $this->assertEquals('foo:key', $item->getTaggedKey());
+
+        $item = new CacheItem('foo:bar:key');
+        $this->assertEquals('foo:bar:key', $item->getTaggedKey());
+    }
+}

--- a/tests/TaggablePoolTraitTest.php
+++ b/tests/TaggablePoolTraitTest.php
@@ -28,6 +28,9 @@ class TaggablePoolTraitTest extends \PHPUnit_Framework_TestCase
         $key1 = $cache->exposeGenerateCacheKey($inputKey, ['abc', '123']);
         $key2 = $cache->exposeGenerateCacheKey($inputKey, ['123', 'abc']);
         $this->assertTrue($key1 === $key2, 'Order should not matter when generating cache keys');
+
+        $key1 = $cache->exposeGenerateCacheKey($inputKey, []);
+        $this->assertTrue($inputKey === $key1, 'Key should not be altered if no tags used. ');
     }
 
     public function testFlushTag()


### PR DESCRIPTION
Since colon (:) is not allowed in the cache key we will not fear a key collision. 

Tags are saved in the cache as `tag:$name`. The calling library could never store a cache item like that and overwrite our tag item. 

This PR does also include validation for the tag name and an interface for the Item. We need a new interface for the Item because of:

> Libraries are responsible for their own escaping of key strings as appropriate, but MUST be able to return the original unmodified key string.
