### PR TITLE
Hierarchy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: php
 php:
-  - "7.0"
-  - "5.6"
-  - "5.5"
-  - "5.4"
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+  - hhvm
+
 
 matrix:
   fast_finish: true
@@ -11,7 +13,7 @@ matrix:
 sudo: false
 
 before_install:
-    - phpenv config-rm xdebug.ini
+    - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi;
     - pip install --user codecov
 
 before_script:

--- a/src/TaggableItemInterface.php
+++ b/src/TaggableItemInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/TaggableItemTrait.php
+++ b/src/TaggableItemTrait.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -38,10 +38,10 @@ trait TaggableItemTrait
      */
     protected function getKeyFromTaggedKey($taggedKey)
     {
-        if (false === $pos = strrpos($taggedKey, ':')) {
+        if (false === $pos = strpos($taggedKey, ':')) {
             return $taggedKey;
         }
 
-        return substr($taggedKey, $pos + 1);
+        return substr($taggedKey, 0, $pos);
     }
 }

--- a/src/TaggablePoolInterface.php
+++ b/src/TaggablePoolInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -19,6 +19,8 @@ namespace Cache\Taggable;
  */
 interface TaggablePoolInterface
 {
+    const TAG_SEPARATOR = ':';
+
     public function getItem($key, array $tags = []);
 
     public function getItems(array $keys = [], array $tags = []);

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -107,7 +107,7 @@ trait TaggablePoolTrait
         }
         $tagsNamespace = sha1(implode('|', $tagIds));
 
-        return $tagsNamespace.':'.$key;
+        return $key.TaggablePoolInterface::TAG_SEPARATOR.$tagsNamespace;
     }
 
     /**
@@ -138,7 +138,7 @@ trait TaggablePoolTrait
      */
     private function getTagKey($name)
     {
-        return 'tag:'.$name;
+        return $name.TaggablePoolInterface::TAG_SEPARATOR.'tag';
     }
 
     /**

--- a/tests/Helper/CacheItem.php
+++ b/tests/Helper/CacheItem.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/tests/Helper/CachePool.php
+++ b/tests/Helper/CachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/tests/TaggableItemTraitTest.php
+++ b/tests/TaggableItemTraitTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
@@ -20,10 +20,10 @@ class TaggableItemTraitTest extends \PHPUnit_Framework_TestCase
         $item = new CacheItem('key');
         $this->assertEquals('key', $item->getKey());
 
-        $item = new CacheItem('foo:key');
+        $item = new CacheItem('key:foo');
         $this->assertEquals('key', $item->getKey());
 
-        $item = new CacheItem('foo:bar:key');
+        $item = new CacheItem('key:foo:bar');
         $this->assertEquals('key', $item->getKey());
     }
 
@@ -32,10 +32,10 @@ class TaggableItemTraitTest extends \PHPUnit_Framework_TestCase
         $item = new CacheItem('key');
         $this->assertEquals('key', $item->getTaggedKey());
 
-        $item = new CacheItem('foo:key');
-        $this->assertEquals('foo:key', $item->getTaggedKey());
+        $item = new CacheItem('key:foo');
+        $this->assertEquals('key:foo', $item->getTaggedKey());
 
-        $item = new CacheItem('foo:bar:key');
-        $this->assertEquals('foo:bar:key', $item->getTaggedKey());
+        $item = new CacheItem('key:foo:bar');
+        $this->assertEquals('key:foo:bar', $item->getTaggedKey());
     }
 }

--- a/tests/TaggablePoolTraitTest.php
+++ b/tests/TaggablePoolTraitTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache\taggable-cache package.
  *
- * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.


### PR DESCRIPTION
The tag has to be at the end if we are going to check for the separator "|" in the beginning of the string. 

If merged this will break existing keys and a new minor release is required. 

Related PR: https://github.com/php-cache/predis-adapter/pull/7
