### PR TITLE
Don't use colon to prefix keys

### DIFF
--- a/src/TaggableItemTrait.php
+++ b/src/TaggableItemTrait.php
@@ -38,7 +38,7 @@ trait TaggableItemTrait
      */
     protected function getKeyFromTaggedKey($taggedKey)
     {
-        if (false === $pos = strrpos($taggedKey, ':')) {
+        if (false === $pos = strrpos($taggedKey, '|')) {
             return $taggedKey;
         }
 

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -144,7 +144,6 @@ trait TaggablePoolTrait
     /**
      * A TagId is retrieved from cache using the TagKey.
      *
-     * @param \Psr\Cache\CacheItemPoolInterface $storage
      * @param CacheItemInterface                $item
      *
      * @return string

--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -57,7 +57,7 @@ trait TaggablePoolTrait
     abstract protected function getItemWithoutGenerateCacheKey($key);
 
     /**
-     * Make sure we do not use any invalid characters in the tag name. The actual tag name will be "tag:$name".
+     * Make sure we do not use any invalid characters in the tag name. The actual tag name will be "tag|$name".
      *
      * @param string $name
      */
@@ -107,7 +107,7 @@ trait TaggablePoolTrait
         }
         $tagsNamespace = sha1(implode('|', $tagIds));
 
-        return $tagsNamespace.':'.$key;
+        return $tagsNamespace.'|'.$key;
     }
 
     /**
@@ -138,7 +138,7 @@ trait TaggablePoolTrait
      */
     private function getTagKey($name)
     {
-        return 'tag:'.$name;
+        return 'tag|'.$name;
     }
 
     /**

--- a/tests/TaggableItemTraitTest.php
+++ b/tests/TaggableItemTraitTest.php
@@ -20,10 +20,10 @@ class TaggableItemTraitTest extends \PHPUnit_Framework_TestCase
         $item = new CacheItem('key');
         $this->assertEquals('key', $item->getKey());
 
-        $item = new CacheItem('foo:key');
+        $item = new CacheItem('foo|key');
         $this->assertEquals('key', $item->getKey());
 
-        $item = new CacheItem('foo:bar:key');
+        $item = new CacheItem('foo|bar|key');
         $this->assertEquals('key', $item->getKey());
     }
 
@@ -32,10 +32,10 @@ class TaggableItemTraitTest extends \PHPUnit_Framework_TestCase
         $item = new CacheItem('key');
         $this->assertEquals('key', $item->getTaggedKey());
 
-        $item = new CacheItem('foo:key');
-        $this->assertEquals('foo:key', $item->getTaggedKey());
+        $item = new CacheItem('foo|key');
+        $this->assertEquals('foo|key', $item->getTaggedKey());
 
-        $item = new CacheItem('foo:bar:key');
-        $this->assertEquals('foo:bar:key', $item->getTaggedKey());
+        $item = new CacheItem('foo|bar|key');
+        $this->assertEquals('foo|bar|key', $item->getTaggedKey());
     }
 }


### PR DESCRIPTION
Colons should not be used in implementing libraries & taggable-cache is just that.

From the PSR-6 spec (http://www.php-fig.org/psr/psr-6/):
`The following characters are reserved for future extensions and MUST NOT be supported by implementing libraries: {}()/\@:`

For one, it would be safer to switch to a character that is not reserved, to make sure this implementation matches the spec.
Second, I've been continuing the work @Nyholm started on https://github.com/matthiasmullie/scrapbook/pull/5, but I've split it off into a separate project: https://github.com/matthiasmullie/taggable-cache, so it can be used with every other PSR-6 implementation. But taggable-cache is using an invalid character, that can't work.
