### PR TITLE
Removed sha1 on the tag namespace.

### DIFF
--- a/src/TaggablePoolTrait.php
+++ b/src/TaggablePoolTrait.php
@@ -105,7 +105,7 @@ trait TaggablePoolTrait
                 $tagIds[] = $this->getTagId($tag);
             }
         }
-        $tagsNamespace = sha1(implode('|', $tagIds));
+        $tagsNamespace = implode('|', $tagIds);
 
         return $key.TaggablePoolInterface::TAG_SEPARATOR.$tagsNamespace;
     }


### PR DESCRIPTION
Why do we need to `sha1()` this? I believe it was because we did not want a pipe "|" in the tag namespace. 

The implication of this will be shorter keys but the cache storage must support pipes in the key. 

Related PRs: https://github.com/php-cache/memcached-adapter/pull/6 
